### PR TITLE
Added Anudeep's Facebook blocklist

### DIFF
--- a/lists.json
+++ b/lists.json
@@ -73,6 +73,14 @@
     "url": "https://raw.githubusercontent.com/anudeepND/blacklist/master/CoinMiner.txt"
   },
   {
+    "id": "anudeep-blacklist-facebook",
+    "name": "Anudeep's Blacklist (Facebook)",
+    "website": "https://github.com/anudeepND/blacklist",
+    "description": "Block all Facebook domains (including Messenger, Instagram and Whatsapp).",
+    "categories": ["social", "privacy"],
+    "url": "https://raw.githubusercontent.com/anudeepND/blacklist/master/facebook.txt"
+  },
+  {
     "id": "notracking-domains",
     "name": "notracking (domains)",
     "website": "https://github.com/notracking/hosts-blocklists",


### PR DESCRIPTION
I added Anudeep's blocklist that blocks all Facebook domains, both tracking and needed for services to function (including Messenger, Instagram and Whatsapp). That's for people who don't use anything owned by Facebook, because it blocks even "legit" Facebook sites.