### PR TITLE
Add andryou blocklists

### DIFF
--- a/blocklists/andryou-chibi.json
+++ b/blocklists/andryou-chibi.json
@@ -1,0 +1,6 @@
+{
+  "name": "andryou - chibi",
+  "website": "https://gitlab.com/andryou/block",
+  "description": "Block ads, analytics/trackers, malware, ransomware, phishing, malvertising, mobile ads/tracking, fake news, the Luminati/Hola network, cryptominers, scam retailers, and Windows telemetry. Basic blocking.",
+  "source": "https://gitlab.com/andryou/block/raw/master/chibi-strict-compressed-domains"
+}

--- a/blocklists/andryou-kouhai.json
+++ b/blocklists/andryou-kouhai.json
@@ -1,0 +1,6 @@
+{
+  "name": "andryou - kouhai",
+  "website": "https://gitlab.com/andryou/block",
+  "description": "Block ads, analytics/trackers, malware, ransomware, phishing, malvertising, mobile ads/tracking, fake news, the Luminati/Hola network, cryptominers, scam retailers, and Windows telemetry. Balanced blocking.",
+  "source": "https://gitlab.com/andryou/block/raw/master/kouhai-strict-compressed-domains"
+}

--- a/blocklists/andryou-senpai.json
+++ b/blocklists/andryou-senpai.json
@@ -1,0 +1,6 @@
+{
+  "name": "andryou - senpai",
+  "website": "https://gitlab.com/andryou/block",
+  "description": "Block ads, analytics/trackers, malware, ransomware, phishing, malvertising, mobile ads/tracking, fake news, the Luminati/Hola network, cryptominers, scam retailers, and Windows telemetry. Robust blocking.",
+  "source": "https://gitlab.com/andryou/block/raw/master/senpai-strict-compressed-domains"
+}


### PR DESCRIPTION
Source: https://gitlab.com/andryou/block

> Block ads, analytics/trackers, malware, ransomware, phishing, malvertising, mobile ads/tracking, fake news, the Luminati/Hola network, cryptominers, scam retailers, and Windows telemetry.

I selected the strict, optimized (wildcarded) domains variant of each list, the lists are:

* Chibi = basic blocking
* Kouhai = balanced blocking
* Senpai = robust blocking

Up for consideration!