### PR TITLE
Update the No-g name.

### DIFF
--- a/blocklists/no-g.json
+++ b/blocklists/no-g.json
@@ -1,6 +1,0 @@
-{
-  "name": "No G",
-  "website": "https://github.com/nickspaargaren/pihole-google",
-  "description": "Completely block all Google-related services. And I've said completely.",
-  "source": "https://raw.githubusercontent.com/nickspaargaren/pihole-google/master/wildcards-domains"
-}

--- a/blocklists/no-google.json
+++ b/blocklists/no-google.json
@@ -1,6 +1,6 @@
 {
   "name": "No Google",
-  "website": "https://github.com/nickspaargaren/pihole-google",
+  "website": "https://github.com/nickspaargaren/no-google",
   "description": "Completely block Google and its services",
   "source": "https://raw.githubusercontent.com/nickspaargaren/no-google/master/wildcards-domains"
 }

--- a/blocklists/no-google.json
+++ b/blocklists/no-google.json
@@ -1,0 +1,6 @@
+{
+  "name": "No Google",
+  "website": "https://github.com/nickspaargaren/pihole-google",
+  "description": "Completely block Google and its services",
+  "source": "https://raw.githubusercontent.com/nickspaargaren/no-google/master/wildcards-domains"
+}


### PR DESCRIPTION
Little update, on this list info https://github.com/nextdns/metadata/pull/13
It was previously name pihole-google, but at the time I’ve pull requested its inclusion into NextDNS, it lost a bit it’s ¨pihole usage exclusivity¨, and though, renamed it as No-G.
As we’ve decided to adopt the name no-*companyname type of name, It was necessary to update it, from the NextDNS listing as you can see.
Note that I’ve changed the file name in itself, you can conserve the original file name ¨no-g.json¨ if you prefer, as this doesn’t change anything in the end for the end-user.
https://github.com/nickspaargaren/no-google/issues/25