### PR TITLE
coinminer.txt by anudeepND is discontinued

### DIFF
--- a/security/cryptojacking.json
+++ b/security/cryptojacking.json
@@ -1,7 +1,6 @@
 {
   "sources": [
-    "https://raw.githubusercontent.com/hoshsadiq/adblock-nocoin-list/master/hosts.txt",
-    "https://raw.githubusercontent.com/anudeepND/blacklist/master/CoinMiner.txt"
+    "https://raw.githubusercontent.com/hoshsadiq/adblock-nocoin-list/master/hosts.txt"
   ],
   "exclusions": [],
   "additions": []


### PR DESCRIPTION
From the project [homepage](https://github.com/anudeepND/blacklist), the author reports that he has abandoned the list (last update February 2019).