### PR TITLE
Replace CHEF-KOCH Spotify list [EOL] with SpotAdBlock

### DIFF
--- a/privacy/blocklists/chef-koch-spotify.json
+++ b/privacy/blocklists/chef-koch-spotify.json
@@ -1,6 +1,0 @@
-{
-  "name": "CHEF-KOCH's HOSTS Spotify Ad-Filter List",
-  "website": "https://github.com/CHEF-KOCH/Spotify-Ad-free",
-  "description": "Blocks all Spotify Ads, easy peasy lemon squeezy!",
-  "source": "https://raw.githubusercontent.com/CHEF-KOCH/Spotify-Ad-free/master/filter/Spotify-HOSTS.txt"
-}

--- a/privacy/blocklists/x0uid-spotifyadblock.json
+++ b/privacy/blocklists/x0uid-spotifyadblock.json
@@ -1,0 +1,6 @@
+{
+  "name": "x0uid's SpotifyAdBlock",
+  "website": "https://github.com/x0uid/SpotifyAdBlock",
+  "description": "Protect your privacy by blocking all annoying Spotify ads & analytics.",
+  "source": "https://raw.githubusercontent.com/x0uid/SpotifyAdBlock/master/hosts"
+}


### PR DESCRIPTION
Looks like [CHEF-KOCH's list](https://github.com/CHEF-KOCH/Spotify-Ad-free/issues/12#issuecomment-586720054) is not maintained anymore so I suggest removal or replacement with [x0uid's list](https://github.com/x0uid/SpotifyAdBlock).