### PR TITLE
Add Zoom to the parental categories

### DIFF
--- a/parentalcontrol/services/zoom
+++ b/parentalcontrol/services/zoom
@@ -1,0 +1,3 @@
+zoom.us
+zoom.com
+zoomus.zendesk.com


### PR DESCRIPTION
I'm adding Zooom to allow all NextDNS users to quickly block zoom.

See:
https://www.fastcompany.com/90486586/zoom-banned-from-new-york-city-schools-due-to-privacy-and-security-flaws