### PR TITLE
Add the CoinBlockerLists (threat-intelligence-feeds)

### DIFF
--- a/security/threat-intelligence-feeds
+++ b/security/threat-intelligence-feeds
@@ -34,3 +34,5 @@ https://gist.githubusercontent.com/BBcan177/4a8bf37c131be4803cb2/raw/2577a3a8474
 https://www.botvrij.eu/data/ioclist.domain.raw
 https://osint.bambenekconsulting.com/feeds/c2-dommasterlist.txt
 https://urlhaus.abuse.ch/downloads/hostfile
+https://zerodot1.gitlab.io/CoinBlockerLists/hosts
+https://zerodot1.gitlab.io/CoinBlockerLists/hosts_optional


### PR DESCRIPTION
Contribute: https://gitlab.com/ZeroDot1/CoinBlockerLists/issues/new
Copyright: (c) ZeroDot1, 2020
Description: This list disables browser based miners such as coin-hive
Donate: https://tinyurl.com/r3m4yy4 Every donation keeps the future development going. Thank you.
Homepage: https://gitlab.com/ZeroDot1/CoinBlockerLists/
Last modified: 2020-03-17 14:58:37 (Next update is in preparation)
License: https://gitlab.io/ZeroDot1/CoinBlockerLists/LICENSE