### PR TITLE
GAFAM - Add darksky.net (Apple)

### DIFF
--- a/analytics/gafam.json
+++ b/analytics/gafam.json
@@ -354,7 +354,8 @@
       "mzstatic.com.edgekey.net",
       "origin-apple.com.akadns.net",
       "push-apple.com.akadns.net",
-      "shazam.com"
+      "shazam.com",
+      "darksky.net"
     ]
   },
   {


### PR DESCRIPTION
Dark Sky was acquired by Apple. https://blog.darksky.net/dark-sky-has-a-new-home/