### PR TITLE
Update links to my lists with description update

### DIFF
--- a/privacy/blocklists/lightswitch05-ads-tracking.json
+++ b/privacy/blocklists/lightswitch05-ads-tracking.json
@@ -1,7 +1,7 @@
 {
   "name": "Lightswitch05 - Ads & Tracking",
   "website": "https://www.github.developerdan.com/hosts",
-  "description": "A programmatically expanded list of hosts I've found to not be on other lists.",
+  "description": "A programmatically expanded list of hosts used for advertisements and tracking. This is my primary list and I recommend using it.",
   "source": {
     "url": "https://www.github.developerdan.com/hosts/lists/ads-and-tracking-extended.txt",
     "format": "hosts"

--- a/privacy/blocklists/lightswitch05-ads-tracking.json
+++ b/privacy/blocklists/lightswitch05-ads-tracking.json
@@ -3,7 +3,7 @@
   "website": "https://www.github.developerdan.com/hosts",
   "description": "A programmatically expanded list of hosts I've found to not be on other lists.",
   "source": {
-    "url": "https://raw.githubusercontent.com/lightswitch05/hosts/master/ads-and-tracking-extended.txt",
+    "url": "https://www.github.developerdan.com/hosts/lists/ads-and-tracking-extended.txt",
     "format": "hosts"
   }
 }

--- a/privacy/blocklists/lightswitch05-tracking-aggressive.json
+++ b/privacy/blocklists/lightswitch05-tracking-aggressive.json
@@ -3,7 +3,7 @@
   "website": "https://www.github.developerdan.com/hosts",
   "description": "A very aggressive block list for tracking, geo-targeting, & ads. This list will likely break functionality, so do not use it unless you are willing to maintain your own whitelist.",
   "source": {
-    "url": "https://raw.githubusercontent.com/lightswitch05/hosts/master/tracking-aggressive-extended.txt",
+    "url": "https://www.github.developerdan.com/hosts/lists/tracking-aggressive-extended.txt",
     "format": "hosts"
   }
 }


### PR DESCRIPTION
I intend on reorganizing this repo in the near future. Please use the links provided everywhere in the project to access the files. It is hosted on github pages - so should have the same reliability as the `raw` links.

Also update list description. 