### PR TITLE
Remove duplicate doh.applied-privacy.net entry

### DIFF
--- a/parentalcontrol/bypass-methods
+++ b/parentalcontrol/bypass-methods
@@ -57,7 +57,6 @@ dns.digitale-gesellschaft.ch
 doh.libredns.gr
 fi.doh.dns.snopyta.org
 odvr.nic.cz
-doh.applied-privacy.net
 doh.xfinity.com
 dns.containerpi.co
 dns.alekberg.net


### PR DESCRIPTION
This was removed from my pull #154 , but doh.applied-privacy.net is listed twice.

cc. @romaincointepas 