### PR TITLE
Add some missing ebay URLs

### DIFF
--- a/parentalcontrol/services/ebay
+++ b/parentalcontrol/services/ebay
@@ -18,3 +18,8 @@ ebay.com.cn
 ebay.com.hk
 ebay.com.my
 ebay.com.sg
+ebaystatic.ebay.map.fastly.net
+ebaystatic.com
+ebay.com.edgekey.net
+ebayimg.com
+ebaycdn.net


### PR DESCRIPTION
While checking the Next DNS logs I noticed some ebay links that are definitely still missing.