### PR TITLE
[Allow Affiliate & Tracking Links] Whitelist additional Danish hostnames

### DIFF
--- a/privacy/affiliate-tracking-domains
+++ b/privacy/affiliate-tracking-domains
@@ -65,3 +65,6 @@ clickserve.dartsearch.net
 click.pstmrk.it
 analytics.twitter.com
 online.digital-advisor.com
+link.digitaladvisor.dk
+www.partner-ads.com
+online.adservicemedia.dk


### PR DESCRIPTION
In #154 I whitelisted `online.digital-advisor.com` however I forget `link.digitaladvisor.dk` which is used in the redirect chain:
`online.digital-advisor.com > link.digitaladvisor.dk > destination.com` - can be checked/verified on https://webhotelsoversigt.dk/rabatkode/2-rabatkode-til-simply - all buttons

Added `www.partner-ads.com` which was denied in #154, now with a proper example - all "på lager" green buttons on https://nytnetværkskabel.dk

Added `online.adservicemedia.dk` - example https://webhotelsoversigt.dk/rabatkode/19-rabatkode-til-one.com - all buttons