### PR TITLE
Update source url for Energized Basic

### DIFF
--- a/privacy/blocklists/energized-basic.json
+++ b/privacy/blocklists/energized-basic.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/EnergizedProtection/block",
   "description": "Strictly blocks advertisements, malwares, spams, statistics & trackers on both web browsing and applications. An All-Rounder Balanced Protection Pack.",
   "source": {
-    "url": "https://raw.githubusercontent.com/EnergizedProtection/block/master/basic/formats/domains.txt",
+    "url": "https://block.energized.pro/basic/formats/domains.txt",
     "format": "domains"
   }
 }


### PR DESCRIPTION
From the [project homepage,](https://t.me/s/EnergizedProtectionUpdates?before=65) the authors have changend the soure urls away from github to own servers