### PR TITLE
Update source url for Energized Blu Go

### DIFF
--- a/privacy/blocklists/energized-blu-go.json
+++ b/privacy/blocklists/energized-blu-go.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/EnergizedProtection/block",
   "description": "Strictly blocks advertisements, malwares, spams, statistics & trackers on both web browsing and applications. A Lightweight Mid Ranger Protection Pack.",
   "source": {
-    "url": "https://raw.githubusercontent.com/EnergizedProtection/block/master/bluGo/formats/domains.txt",
+    "url": "https://block.energized.pro/bluGo/formats/domains.txt",
     "format": "domains"
   }
 }


### PR DESCRIPTION
From the [project homepage,](https://t.me/s/EnergizedProtectionUpdates?before=65) the authors have changend the soure urls away from github to own servers