### PR TITLE
Update source url for Energized Blu

### DIFF
--- a/privacy/blocklists/energized-blu.json
+++ b/privacy/blocklists/energized-blu.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/EnergizedProtection/block",
   "description": "Strictly blocks advertisements, malwares, spams, statistics & trackers on both web browsing and applications. A Mid Ranger Flagship Protection Pack.",
   "source": {
-    "url": "https://raw.githubusercontent.com/EnergizedProtection/block/master/blu/formats/domains.txt",
+    "url": "https://block.energized.pro/blu/formats/domains.txt",
     "format": "domains"
   }
 }


### PR DESCRIPTION
From the [project homepage,](https://t.me/s/EnergizedProtectionUpdates?before=65) the authors have changend the soure urls away from github to own servers