### PR TITLE
Update source url for Energized Ultimate

### DIFF
--- a/privacy/blocklists/energized-ultimate.json
+++ b/privacy/blocklists/energized-ultimate.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/EnergizedProtection/block",
   "description": "Strictly blocks advertisements, malwares, spams, statistics & trackers on both web browsing and applications. Flagship Protection Pack from Energized Protection.",
   "source": {
-    "url": "https://raw.githubusercontent.com/EnergizedProtection/block/master/ultimate/formats/domains.txt",
+    "url": "https://block.energized.pro/ultimate/formats/domains.txt",
     "format": "domains"
   }
 }


### PR DESCRIPTION
From the [project homepage,](https://t.me/s/EnergizedProtectionUpdates?before=65) the authors have changend the soure urls away from github to own servers