### PR TITLE
Update source url for Energized Xtreme

### DIFF
--- a/privacy/blocklists/energized-xtreme-extension.json
+++ b/privacy/blocklists/energized-xtreme-extension.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/EnergizedProtection/block",
   "description": "Strictly blocks advertisements, malwares, spams, statistics & trackers on both web browsing and applications. An Extreme Solution for Ultimate Protection.",
   "source": {
-    "url": "https://raw.githubusercontent.com/EnergizedProtection/block/master/extensions/xtreme/formats/domains.txt",
+    "url": "https://block.energized.pro/extensions/xtreme/formats/domains.txt",
     "format": "domains"
   }
 }


### PR DESCRIPTION
From the [project homepage,](https://t.me/s/EnergizedProtectionUpdates?before=65) the authors have changend the soure urls away from github to own servers