### PR TITLE
[affiliate whitelist] add support for epicgames.com email links

### DIFF
--- a/privacy/affiliate-tracking-domains
+++ b/privacy/affiliate-tracking-domains
@@ -69,3 +69,7 @@ online.digital-advisor.com
 link.digitaladvisor.dk
 www.partner-ads.com
 online.adservicemedia.dk
+# support epicgames links in email
+*.link.epicgames.com
+*.cb.sailthru.com
+*.sailthru.com


### PR DESCRIPTION
I added the following links to my whitelist in order to support clicking the "reset password" link in my email from epicgames.com. I'm not sure if all of their email links follow the same domain recursion, though. :shrug: 