### PR TITLE
Update gafam.json

### DIFF
--- a/analytics/gafam.json
+++ b/analytics/gafam.json
@@ -34,7 +34,6 @@
       "gmail.com",
       "goo.gl",
       "googl.com",
-      "google",
       "google-analytics.com",
       "google.ad",
       "google.ae",


### PR DESCRIPTION
Tiny change to remove **`google`** (no TLD) from "google" list;
It looks like **`google`** was added with the initial **`gafam.json`** commit back in 2019.