### PR TITLE
Create Parental Control : giphy

### DIFF
--- a/parentalcontrol/services/giphy
+++ b/parentalcontrol/services/giphy
@@ -1,0 +1,4 @@
+giphy.com
+giphy.map.fastly.net
+giphy.world
+giphyscripts.s3.amazonaws.com


### PR DESCRIPTION
````
Initial commit for giphy "service" for parental control blocking.
Blocking the apps themselves is another thing,
e.g. the app for Android = `com.giphy.messenger`
& while the $app modifier may be used
for Android, Mac & Windows via AdGuard,
it's not possible unless NextDNS accepts
the type of "domains" required.
If not, this list will only help in blocking the website itself. 👍🏼
````