### PR TITLE
AdGuard VPN

### DIFF
--- a/parentalcontrol/bypass-methods
+++ b/parentalcontrol/bypass-methods
@@ -448,6 +448,7 @@ vpnme.me
 # VPNs
 12vpx.com
 acevpn.com
+adguard-vpn.com
 anonine.com
 anonvpn.io
 anonymize.com


### PR DESCRIPTION
Added the [AdGuard VPN](https://adguard.com/en/blog/adguard-vpn-announcement.html) domain, [adguard-vpn.com](adguard-vpn.com), to the bypass methods list.