### PR TITLE
Drop duplicate and suspended blocklists

### DIFF
--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -33,10 +33,6 @@
       "format": "domains"
     },
     {
-      "url": "https://isc.sans.edu/feeds/suspiciousdomains_High.txt",
-      "format": "domains"
-    },
-    {
       "url": "https://raw.githubusercontent.com/mitchellkrogza/Badd-Boyz-Hosts/master/hosts",
       "format": "hosts"
     },

--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -179,10 +179,6 @@
     {
       "url": "https://data.phishtank.com/data/{PHISHTANK_APP_KEY}/online-valid.csv",
       "format": "phishtank"
-    },
-    {
-      "url": "http://vxvault.net/URL_List.php",
-      "format": "urls"
     }
   ],
   "ignoreSourceFailure": true,

--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -97,10 +97,6 @@
       "format": "domains"
     },
     {
-      "url": "http://phishing.mailscanner.info/phishing.bad.sites.conf",
-      "format": "domains"
-    },
-    {
       "url": "https://raw.githubusercontent.com/infinitytec/blocklists/master/scams-and-phishing.txt",
       "format": "hosts"
     },

--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -179,6 +179,10 @@
     {
       "url": "https://data.phishtank.com/data/{PHISHTANK_APP_KEY}/online-valid.csv",
       "format": "phishtank"
+    },
+    {
+      "url": "http://vxvault.net/URL_List.php",
+      "format": "urls"
     }
   ],
   "ignoreSourceFailure": true,


### PR DESCRIPTION
- [DShield](https://isc.sans.edu/suspicious_domains.html) list was suspended on 3 Jun 2020
  * The website now shows data sources come from URLhaus and PhishTank, both are already utilised here.
- 'Phishing Bad Sites' blocklist is based on PhishTank, according to the [description](https://filterlists.com/lists/phishing-bad-sites).
- [VX Vault](http://vxvault.net/URL_List.php) actively submit links to URLhaus.