### PR TITLE
Update easylist.json

### DIFF
--- a/privacy/blocklists/easylist.json
+++ b/privacy/blocklists/easylist.json
@@ -5,5 +5,8 @@
   "source": {
     "url": "https://easylist.to/easylist/easylist.txt",
     "format": "abp"
-  }
+  },
+  "exclusions": [
+    "*.shortpixel.ai"
+  ]
 }


### PR DESCRIPTION
Excluded domain used by the wordpress ShortPixel plugin as CDN.

Example: 
>https://cdn.shortpixel.ai/client/q_lossy,ret_img/https://ilfotoriparatore.it/wp-content/uploads/2020/06/logo_ilfotoriparatore.png