### PR TITLE
Add CNAME of link.wizzair.com to affiliate domains

### DIFF
--- a/privacy/affiliate-tracking-domains
+++ b/privacy/affiliate-tracking-domains
@@ -111,6 +111,7 @@ se-go.kelkoogroup.net
 shareasale.com
 sk-go.kelkoogroup.net
 solutions.tradedoubler.com
+suite15.emarsys.net # CNAME of link.wizzair.com
 syndication.realsrv.com
 t.co
 t.dripemail2.com


### PR DESCRIPTION
I got an email from WizzAir with the link to their website and it was blocked.