### PR TITLE
Updates Native: Apple

### DIFF
--- a/privacy/native/apple
+++ b/privacy/native/apple
@@ -7,3 +7,4 @@ dzc-metrics.mzstatic.com
 books-analytics-events.news.apple-dns.net
 books-analytics-events.apple.com
 stocks-analytics-events.apple.com
+stocks-analytics-events.news.apple-dns.net

--- a/privacy/native/apple
+++ b/privacy/native/apple
@@ -6,3 +6,4 @@ metrics.mzstatic.com
 dzc-metrics.mzstatic.com
 books-analytics-events.news.apple-dns.net
 books-analytics-events.apple.com
+stocks-analytics-events.apple.com


### PR DESCRIPTION
Two new domains found when using the iOS stocks app. 
Didn't have trouble viewing the stock prices, graphs, or the news articles that show up below them.
The fact that they are analytics domains and they didn't affect the usage of the apps, I think you should consider adding them to the list.

stocks-analytics-events.apple.com
stocks-analytics-events.news.apple-dns.net