### PR TITLE
Update minecraft to add some minecraft servers

### DIFF
--- a/parentalcontrol/services/minecraft
+++ b/parentalcontrol/services/minecraft
@@ -1,1 +1,4 @@
 minecraft.net
+invadedlands.net
+mineheroes.org
+hypixel.net


### PR DESCRIPTION
These additional domains are minecraft server hosting communities.  They are connected to by minecraft client software for multiplayer online games.  They do not host non-minecraft content.  It is not a complete list, just the ones appearing in my son's NextDNS logs.