### PR TITLE
Add Blokada's DuckDuckGo Tracker Radar blocklist

### DIFF
--- a/privacy/blocklists/duckduckgo-tracker-radar.json
+++ b/privacy/blocklists/duckduckgo-tracker-radar.json
@@ -1,0 +1,10 @@
+{
+    "name": "DuckDuckGo Tracker Radar",
+    "website": "https://go.blokada.org/ddgtrackerradar",
+    "description": "Blokada's custom blocklist from the DuckDuckGo Tracker Radar data set.",
+    "source": {
+      "url": "https://blokada.org/blocklists/ddgtrackerradar/standard/hosts.txt",
+      "format": "domains"
+    }
+  }
+  


### PR DESCRIPTION
[Blokada](https://blokada.org/) currently maintains their own [custom, domain-based blocklist](https://go.blokada.org/ddgtrackerradar) based on [DuckDuckGo's Tracker Radar data set](https://spreadprivacy.com/duckduckgo-tracker-radar/). 

The blocklist is currently available in these places:
- https://blokada.org/blocklists/ddgtrackerradar/standard/hosts.txt
- https://github.com/blokadaorg/blokadaorg.github.io/blob/master/blocklists/ddgtrackerradar/standard/hosts.txt

[Previous related discussion](https://github.com/nextdns/metadata/issues/252).