### PR TITLE
Allow Affiliate & Tracking Links: add click.virt.s10.exacttarget.com

### DIFF
--- a/privacy/affiliate-tracking-domains
+++ b/privacy/affiliate-tracking-domains
@@ -34,6 +34,7 @@ click.cptrack.de
 click.linksynergy.com
 click.mail.macmillan.com
 click.pstmrk.it
+click.virt.s10.exacttarget.com
 clickserve.cc-dt.com
 clickserve.dartsearch.net
 clk.boulanger.com


### PR DESCRIPTION
I noticed this domain is used for tracking links in some newsletter. Right now it's not possible to reach any links contained in a newsletter.