### PR TITLE
Add api.miwifi.com

### DIFF
--- a/privacy/native/xiaomi
+++ b/privacy/native/xiaomi
@@ -9,3 +9,4 @@ tracking.miui.com
 tracking.intl.miui.com
 tracking.india.miui.com
 tracking.rus.miui.com
+api.miwifi.com


### PR DESCRIPTION
All the Xiaomi routers send data constantly to api.miwifi.com which is on Singapore and the provider is Alibaba