### PR TITLE
Add rebrandly url-shortner

### DIFF
--- a/privacy/affiliate-tracking-domains
+++ b/privacy/affiliate-tracking-domains
@@ -106,6 +106,7 @@ prf.hn
 prism.app-us1.com
 pt-go.kelkoogroup.net
 qksrv.net
+rebrandlydomain.com
 r20.rs6.net
 rd.bizrate.com # CNAME of link.sylikes.com
 redir.tradedoubler.com


### PR DESCRIPTION
rebrandly.com is a url shortner that doubles up as an affiliate tracker.