### PR TITLE
Delete chef-koch-spotify.json

### DIFF
--- a/privacy/blocklists/chef-koch-spotify.json
+++ b/privacy/blocklists/chef-koch-spotify.json
@@ -1,9 +1,0 @@
-{
-  "name": "CHEF-KOCH's HOSTS Spotify Ad-Filter List",
-  "website": "https://gitlab.com/CHEF-KOCH/cks-filterlist",
-  "description": "Blocks all Spotify Ads, easy peasy lemon squeezy!",
-  "source": {
-    "url": "https://gitlab.com/CHEF-KOCH/cks-filterlist/-/raw/master/Anti-Corp/Spotify/Spotify-HOSTS.txt",
-    "format": "hosts"
-  }
-}


### PR DESCRIPTION
Chef-Koch got banned on GitHub & GitLab because of e.g. steal work from others without any info.
Read about him at https://github.com/arkenfox/user.js/issues/323

This PR also solve https://github.com/nextdns/metadata/pull/73 & https://github.com/nextdns/metadata/pull/344 & https://github.com/nextdns/metadata/issues/387

You realy take action now instead of waiting longer. Doesn't make any sense