### PR TITLE
Added turkish blocklist for bad activities

### DIFF
--- a/privacy/blocklists/tr-phishinglist.json
+++ b/privacy/blocklists/tr-phishinglist.json
@@ -1,0 +1,9 @@
+{
+  "name": "Turkey TR-PhishingList Blacklists",
+  "website": "https://github.com/HorusTeknoloji/TR-PhishingList",
+  "description": "Blocking Phishing, Malvertising, Malware, CryptoJacking, Spyware, Ransomware, Abuse, Scam, Spam, Hijack and more",
+  "source": {
+    "url": "https://raw.githubusercontent.com/HorusTeknoloji/TR-PhishingList/master/url-lists.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
This blacklist includes campaigns targeting to Turkey such as Malvertising, Malware, cryptojacking, Spyware, Ransomware, Abuse, Scam, Spam and is updated regularly

Ref: https://github.com/HorusTeknoloji/TR-PhishingList