### PR TITLE
remove "https://www.malwaredomainlist.com/hostslist/hosts.txt"

### DIFF
--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -1,10 +1,6 @@
 {
   "sources": [
     {
-      "url": "https://www.malwaredomainlist.com/hostslist/hosts.txt",
-      "format": "hosts"
-    },
-    {
       "url": "https://raw.githubusercontent.com/StevenBlack/hosts/master/data/add.Dead/hosts",
       "format": "hosts"
     },


### PR DESCRIPTION
this list is EoL and empty