### PR TITLE
remove "https://mirror1.malwaredomains.com/files/justdomains"

### DIFF
--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -13,10 +13,6 @@
       "format": "domains"
     },
     {
-      "url": "https://mirror1.malwaredomains.com/files/justdomains",
-      "format": "domains"
-    },
-    {
       "url": "https://s3.amazonaws.com/lists.disconnect.me/simple_malware.txt",
       "format": "domains"
     },


### PR DESCRIPTION
URL end in 404 and service is EoL.
Domain also redirect to https://riskanalytics.com/community/
and they write:
> As of November 30th, 2020, both AutoShun and Malware Domains feeds will be shut off, and subscribers will no longer receive intel from those sources.