### PR TITLE
Dead upstream sources for Threat Intelligence Feeds

### DIFF
--- a/privacy/affiliate-tracking-domains
+++ b/privacy/affiliate-tracking-domains
@@ -320,6 +320,7 @@ link.digitaladvisor.dk
 link.epicgames.com
 link.freshmail.mx
 list-manage.com
+lnks.gd
 mmtro.com
 monitor.clickcease.com
 mx-go.kelkoogroup.net

--- a/privacy/affiliate-tracking-domains
+++ b/privacy/affiliate-tracking-domains
@@ -320,7 +320,6 @@ link.digitaladvisor.dk
 link.epicgames.com
 link.freshmail.mx
 list-manage.com
-lnks.gd
 mmtro.com
 monitor.clickcease.com
 mx-go.kelkoogroup.net

--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -45,10 +45,6 @@
       "format": "domains"
     },
     {
-      "url": "https://mirror.cedia.org.ec/malwaredomains/immortal_domains.txt",
-      "format": "domains"
-    },
-    {
       "url": "https://bitbucket.org/ethanr/dns-blacklists/raw/master/bad_lists/Mandiant_APT1_Report_Appendix_D.txt",
       "format": "domains"
     },

--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -1,10 +1,6 @@
 {
   "sources": [
     {
-      "url": "https://www.malwaredomainlist.com/hostslist/hosts.txt",
-      "format": "hosts"
-    },
-    {
       "url": "https://raw.githubusercontent.com/StevenBlack/hosts/master/data/add.Dead/hosts",
       "format": "hosts"
     },

--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -9,10 +9,6 @@
       "format": "domains"
     },
     {
-      "url": "https://s3.amazonaws.com/lists.disconnect.me/simple_malware.txt",
-      "format": "domains"
-    },
-    {
       "url": "https://phishing.army/download/phishing_army_blocklist.txt",
       "format": "domains"
     },


### PR DESCRIPTION
The upstream sources for Threat Intelligence Feeds are dead:
https://www.malwaredomainlist.com/hostslist/hosts.txt
https://s3.amazonaws.com/lists.disconnect.me/simple_malware.txt
https://mirror.cedia.org.ec/malwaredomains/immortal_domains.txt

Cheers
