### PR TITLE
Block Additional Minecraft Hosts

### DIFF
--- a/parentalcontrol/services/minecraft
+++ b/parentalcontrol/services/minecraft
@@ -1,1 +1,3 @@
 minecraft.net
+minecraftservices.com
+mojang.com


### PR DESCRIPTION
This adds more Minecraft-related domains to block.

I used [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html) to boot up [Minecraft (Java Edition)](https://www.minecraft.net/en-us/store/minecraft-java-edition) and found the following domains were in use. 

```
libraries.minecraft.net
minecraft.net
pc.realms.minecraft.net
resources.download.minecraft.net
api.minecraftservices.com
minecraftservices.com
authserver.mojang.com
launcher.mojang.com
launchercontent.mojang.com
launchermeta.mojang.com
mojang.com
piston-meta.mojang.com
device.auth.xboxlive.com
title.mgt.xboxlive.com
```

Additionally [wiki.vg](https://wiki.vg/Mojang_API) mentions the following domains:

```
minecraft.net
session.minecraft.net
textures.minecraft.net
account.mojang.com
api.mojang.com
authserver.mojang.com
mojang.com
sessionserver.mojang.com
status.mojang.com
```

Removing `xboxlive.com` (As that's used for more than just Minecraft), we can just block these (As I understand NextDNS to also block subdomains by default):

```
minecraft.net
minecraftservices.com
mojang.com
```

Open to feedback!