### PR TITLE
Adds Formspark exclusions

### DIFF
--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -224,6 +224,7 @@
     "*.files.1drv.com",
     "*.files.cloud.orange.fr",
     "*.forms.gle",
+    "*.formspark.io",
     "*.ghostbin.co",
     "*.github.com",
     "*.githubusercontent.com",
@@ -369,6 +370,7 @@
     "simp.ly",
     "sites.google.com",
     "storage.googleapis.com",
+    "submit-form.com",
     "sytes.net",
     "weebly.com",
     "zapto.org"


### PR DESCRIPTION
Bjorn from Formspark here

I would like to request the whitelisting of the following domains

- *.formspark.io
- submit-form.com

These domains are used by https://formspark.io/, a form to email service.

While occasionally our service is used by malicious actors, this only represents a minor percentage of our user base.

The blacklisting of these domains severely affects certain users

I have created a more targeted whitelist request at https://github.com/anudeepND/whitelist, but unfortunately, this repository seems to be very inactive, with 0 commits in 2021.

Thanks!