### PR TITLE
block amzn short domains

### DIFF
--- a/parentalcontrol/services/amazon
+++ b/parentalcontrol/services/amazon
@@ -17,3 +17,7 @@ amazon.nl
 amazon.sa
 amazon.sg
 amazon.pl
+amzn.ae
+amzn.com
+amzn.in
+amzn.sg


### PR DESCRIPTION
Whilst amzn.in and amzn.ae redirect to
full domain names viz amazon.in and amazon.ae,
amzn.sg and amzn.com serve as api and
e-commerce endpoints respectively.