### PR TITLE
Removed Italian Infosec Cert-PA List

### DIFF
--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -101,10 +101,6 @@
       "format": "hosts"
     },
     {
-      "url": "https://infosec.cert-pa.it/analyze/listdomains.txt",
-      "format": "domains"
-    },
-    {
       "url": "https://www.stopforumspam.com/downloads/toxic_domains_whole.txt",
       "format": "domains"
     },


### PR DESCRIPTION
Removed https://infosec.cert-pa.it/analyze/listdomains.txt because the project is no longer supported by Italian Cert PA .