### PR TITLE
Add OISD Basic list

### DIFF
--- a/privacy/blocklists/oisd-basic.json
+++ b/privacy/blocklists/oisd-basic.json
@@ -1,0 +1,9 @@
+{
+  "name": "oisd basic",
+  "website": "https://oisd.nl",
+  "description": "OISD Basic list is a smaller, less comprehensive variant of the OISD (full) list.  Basic focuses mainly on Ads, (Mobile) App Ads",
+  "source": {
+    "url": "https://dblw.oisd.nl/basic",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
OISD has a basic list which is lighter weight than the full (normal) list.
"The Basic list is a smaller, less comprehensive variant of the full list, which focussus mainly on Ads, (Mobile) App Ads"

In my experience the OISD full list can occasionally have annoying false positives, regardless of what the author says.  I feel his comments are only designed to have more people report the false positives to him but I'm afraid we don't all have time to do that regularly.

Either way, could this list please be added as an alternative option?

Thank you