### PR TITLE
Clefspeare13/pornhosts

### DIFF
--- a/parentalcontrol/categories/porn.json
+++ b/parentalcontrol/categories/porn.json
@@ -5,7 +5,10 @@
       "format": "hosts"
     },
     {
+      "name": "Porn Hosts",
+      "website": "https://mypdns.org/my-privacy-dns/porn-records",
       "url": "https://mypdns.org/clefspeare13/pornhosts/-/raw/master/download_here/0.0.0.0/hosts",
+      "description": "Curated and well-maintained hostfile to stop porn by My PRivacy DNS's Porn Records. Updated almost daily",
       "format": "hosts"
     },
     {
@@ -46,26 +49,6 @@
     "*.zaobao.com.sg"
   ],
   "additions": [
-    "awemdia.com",
-    "babes.com",
-    "hotgaylist.com",
-    "niceteentubes.com",
-    "peeperz.com",
-    "playboytv.com",
-    "porniq.com",
-    "pornlaser.com",
-    "sextube.com",
-    "skipthegames.com",
-    "sukebei.nyaa.net",
-    "teen-xxx-videos.net",
-    "teen18pussy.com",
-    "teenafterteen.com",
-    "teenfreshporn.com",
-    "teenliketube.com",
-    "teenlovestube.com",
-    "viptube.com",
-    "vptpsn.com",
-    "whynotbi.com",
-    "xhcdn.com"
+    
   ]
 }

--- a/parentalcontrol/categories/porn.json
+++ b/parentalcontrol/categories/porn.json
@@ -5,7 +5,7 @@
       "format": "hosts"
     },
     {
-      "url": "https://raw.githubusercontent.com/Clefspeare13/pornhosts/master/0.0.0.0/hosts",
+      "url": "https://mypdns.org/clefspeare13/pornhosts/-/raw/master/download_here/0.0.0.0/hosts",
       "format": "hosts"
     },
     {


### PR DESCRIPTION
Do to the take down by Github, the earlier announced time for merging the
sourced records from the  clefspeare13/pornhosts  into
Pron-Records have arrived and have happened when you read
this README. It means all records now are 100% controlled by
Pron-Records without exceptions.

This means all future builds are done from the earlier submit_here
folder + the matrix of files used to build a hosts,
Pi-hole and AdGuard blacklist

Source: https://mypdns.org/clefspeare13/pornhosts/-/tree/master/#pornhosts-a-consolidated-anti-porn-hosts-file

------------------

Even the hosts list is continued as usual, and will be that for a long period of time, then my personal recommendation would be that there would be a way to include several plain lists as that would keep this filter way more up to date, as you could benefit from importing directly from [Porn-Records](https://mypdns.org/my-privacy-dns/porn-records)

Thanks for the reminder by @Rexadev in https://github.com/tiuxo/hosts/pull/29#issuecomment-992761482