### PR TITLE
IoC for the current log4shell attack campaign

### DIFF
--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -199,6 +199,10 @@
     {
       "url": "https://raw.githubusercontent.com/guardicore/labs_campaigns/master/Autodiscover/autodiscover-tlds.txt",
       "format": "hosts"
+    },
+    {
+      "url": "https://cert-agid.gov.it/download/log4shell-iocs-raw-domain.txt",
+      "format": "domains"
     }
   ],
   "ignoreSourceError": true,


### PR DESCRIPTION
Source: https://cert-agid.gov.it/news/cert-agid-condivide-i-propri-ioc-per-la-mitigazione-degli-attacchi-log4shell/