### PR TITLE
Remove SANS feed

### DIFF
--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -29,10 +29,6 @@
       "format": "domains"
     },
     {
-      "url": "https://isc.sans.edu/feeds/suspiciousdomains_High.txt",
-      "format": "domains"
-    },
-    {
       "url": "https://raw.githubusercontent.com/mitchellkrogza/Badd-Boyz-Hosts/master/hosts",
       "format": "hosts"
     },


### PR DESCRIPTION
https://www.dshield.org/forums/diary/Suspending+Suspicious+Domain+Feed+Update+to+Researcher+IP+Feed/26204/

The list is down for more than a year now.