### PR TITLE
add cisco Umbrella doh

### DIFF
--- a/parentalcontrol/bypass-methods
+++ b/parentalcontrol/bypass-methods
@@ -5,6 +5,7 @@ mask.icloud.com
 mask-h2.icloud.com
 
 # Encrypted DNS
+doh.umbrella.com
 1dot1dot1dot1.cloudflare-dns.com
 8888.google
 a.ns.dnslify.com


### PR DESCRIPTION
Add Cisco Umbrella DoH server: 
https://support.umbrella.com/hc/en-us/articles/360043574271-Using-DNS-over-HTTPS-DoH-with-Umbrella