### PR TITLE
Add some known url-shorteners

### DIFF
--- a/security/url-shorteners
+++ b/security/url-shorteners
@@ -78,6 +78,7 @@ boi.re
 bote.me
 bougn.at
 br4.in
+bre.is
 brk.to
 brzu.net
 buff.ly
@@ -115,6 +116,7 @@ daa.pl
 dai.ly
 dd.ma
 ddp.net
+disq.us
 dft.ba
 dlvr.it
 doiop.com
@@ -141,6 +143,7 @@ freze.it
 fur.ly
 fxn.ws
 g00.me
+geni.us
 gg.gg
 goo-gl.me
 goo.gl
@@ -213,6 +216,7 @@ minu.me
 more.sh
 mut.lu
 myurl.in
+n9.cl
 nbcnews.to
 net.ms
 net46.net
@@ -263,6 +267,7 @@ redu.it
 ref.so
 reise.lc
 relink.fr
+reurl.cc
 reut.rs
 ri.ms
 riz.cz
@@ -289,6 +294,7 @@ skr.sk
 skroc.pl
 smll.co
 sn.im
+snip.ly
 snsw.us
 soo.gd
 spn.sr


### PR DESCRIPTION
I'm also working on some domain blocking, OSINT, security research, been noticed that URL shorteners are pretty common to be blocked as malware leverage those services a lot, but blocking them will affect many normal usages.

It's nice to see that NextDNS is maintaining a url-shortener list, would like to contribute some data I have so that this list can be more robust!