### PR TITLE
Update README.md about bug report method

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Create an issue (or even better, a PR) on this repository.
 Create an issue (or PR) on this repository. If a domain needs to be added, please detail the steps you made to get this domain queried.
 
 ## Report a NextDNS bug not directly related the data contained in this reposity
-Talk to us via the chat available on https://nextdns.io so we can figure it out and fix it.
+Submit an issue to us via the Help Center on https://help.nextdns.io/category/bugs so we can figure it out and fix it.
 
 ## Request a feature or suggest UX/UI improvements
 We highly recommend creating a post on our subreddit [/r/nextdns](https://www.reddit.com/r/nextdns) to get more visibility (and so that other less tech-savvy users can join the discussion as well).


### PR DESCRIPTION
The chat in https://nextdns.io seemed to be removed for a while.