### PR TITLE
Add Hexxium Creations Threat List in security threat intelligene feed

### DIFF
--- a/security/threat-intelligence-feeds.json
+++ b/security/threat-intelligence-feeds.json
@@ -1,5 +1,9 @@
 {
   "sources": [
+   {
+      "url": "https://raw.githubusercontent.com/HexxiumCreations/threat-list/gh-pages/hosts.txt",
+      "format": "hosts"
+    },
     {
       "url": "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Dead/hosts",
       "format": "hosts"


### PR DESCRIPTION
I have a collection of OSINT about threat hosts here: https://github.com/PeterDaveHello/threat-hostlist, and continue to contribute to some of them with false positives or some intel, would like to see if NextDNS would also like to use it so that the security feature can be more powerful 😄  (Though NextDNS is not the only DNS service I'm using, but I'm a paid user of NextDNS 🎉 ) 

If you do like to have more threat intel sources, I've also compared the threat intel feeds here with my collection, can send them all here, you'll just need to review the PR and accept it 😃 

Reference:
- https://hexxiumcreations.github.io/threat-list/
- https://github.com/HexxiumCreations/threat-list
- https://hexxiumcreations.com/report-malicious-domains-and-ips/