### PR TITLE
Remove ddp.net in url-shorteners, fix #949

### DIFF
--- a/security/url-shorteners
+++ b/security/url-shorteners
@@ -89,7 +89,6 @@ cybr.fr
 cyonix.to
 dai.ly
 dd.ma
-ddp.net
 dinly.co
 disq.us
 dft.ba


### PR DESCRIPTION
ddp.net was originally removed in PR #949 in the commit 2efa04950189939,
but accidently added back by the commit using to resolve the merge
conflict: c809ae1e3456d22e, cc @romaincointepas