### PR TITLE
Remove parked domains in security/url-shorteners

### DIFF
--- a/security/url-shorteners
+++ b/security/url-shorteners
@@ -14,7 +14,6 @@
 2tu.us
 2ty.in
 2u.xf.cz
-3ra.be
 3x.si
 4i.ae
 5url.net
@@ -22,10 +21,8 @@
 6g6.eu
 7.ly
 77.ai
-7fth.cc
 7li.in
 8u.cz
-98.to
 L9.fr
 Lvvk.com
 To8.cc
@@ -36,15 +33,11 @@ ad5.eu
 ad7.biz
 adb.ug
 adf.ly
-adfa.st
-adfly.fr
-adv.li
 ajn.me
 aka.gr
 any.gs
 apne.ws
 aqva.pl
-asso.in
 ayt.fr
 b00.fr
 b23.ru
@@ -70,7 +63,6 @@ buff.ly
 bul.lu
 bxl.me
 bzh.me
-captur.in
 cbs.so
 cbsn.ws
 cc.cc
@@ -82,7 +74,6 @@ clikk.in
 cn86.org
 cur.lv
 cut.pe
-cutt.eu
 cutt.us
 cutu.me
 cybr.fr
@@ -102,12 +93,10 @@ dyo.gs
 ecra.se
 erax.cz
 erw.cz
-ezurl.cc
 fff.to
 filz.fr
 foe.hn
 folu.me
-fur.ly
 fxn.ws
 g00.me
 geni.us
@@ -127,10 +116,7 @@ ick.li
 icks.ro
 iiiii.in
 iky.fr
-ilix.in
 is.gd
-isra.li
-itm.im
 ity.im
 ix.sk
 j.gs
@@ -147,7 +133,6 @@ kxb.me
 l-k.be
 lc-s.co
 lc.cx
-lcut.in
 letop10.
 libero.it
 lien.li
@@ -167,7 +152,6 @@ lihi1.me
 lihi2.me
 lihi3.me
 linkn.co
-llu.ch
 lnk.co
 lnk.ly
 lnk.sk
@@ -195,10 +179,8 @@ o-x.fr
 okok.fr
 oua.be
 ow.ly
-past.is
 pdh.co
 ph.ly
-pin.st
 plots.fr
 pm.wu.cz
 po.st
@@ -217,15 +199,12 @@ qxp.cz
 qxp.sk
 rb6.co
 rcknr.io
-rdz.me
 redir.ec
 redir.fr
-redu.it
 ref.so
 relink.fr
 reurl.cc
 reut.rs
-ri.ms
 riz.cz
 rod.gs
 s-url.fr
@@ -240,7 +219,6 @@ sina.lt
 sk.gy
 skr.sk
 skroc.pl
-smll.co
 sn.im
 snip.ly
 snsw.us
@@ -253,7 +231,6 @@ sy.pe
 t.cn
 t.co
 t.me
-ta.gd
 tabzi.com
 tau.pe
 tdjt.cz
@@ -268,13 +245,11 @@ tinyurl.com
 tinyurl.hu
 tldr.sk
 tllg.net
-tnij.org
 tny.cz
 to.ly
 tohle.de
 tpmr.com
 tr.im
-tr5.in
 trck.me
 trib.al
 trick.ly
@@ -285,8 +260,6 @@ u.to
 uby.es
 ucam.me
 ulmt.in
-upzat.com
-ur1.ca
 url2.fr
 url5.org
 urlin.it
@@ -307,7 +280,6 @@ w1p.fr
 waa.ai
 wapo.st
 web99.eu
-wed.li
 wn.nr
 wp.me
 wtc.la
@@ -320,7 +292,6 @@ x10.mx
 x2c.eu
 x2c.eumx
 xav.cc
-xib.me
 xl8.eu
 xoe.cz
 xrl.us
@@ -331,7 +302,6 @@ xurls.co
 yagoa.fr
 yeca.eu
 yect.com
-yep.it
 yogh.me
 youfap.me
 youtu.be
@@ -341,10 +311,8 @@ z9.fr
 zSMS.net
 zeek.ir
 zip.net
-zkr.cz
 zkrt.cz
 zoodl.com
-zpag.es
 zti.me
 zxq.net
 zzb.bz


### PR DESCRIPTION
Remove parked domains in security/url-shorteners as mentioned in https://github.com/nextdns/metadata/pull/949#issuecomment-1065113662