### PR TITLE
Fixing the display of images on mail.ru

### DIFF
--- a/privacy/blocklists/nextdns-recommended.json
+++ b/privacy/blocklists/nextdns-recommended.json
@@ -26,6 +26,7 @@
     "geo2.adobe.com",
     "get3.adobe.com",
     "mobile.pipe.aria.microsoft.com",
+    "r.mradx.net",
     "s.youtube.com",
     "settings-win.data.microsoft.com",
     "teslarati-com-edge.ntv.io",


### PR DESCRIPTION
Fixing the display of images on mail.ru. Photos of news and notification blocks are not uploaded.