### PR TITLE
Add adclick.g.doubleclick.net

### DIFF
--- a/privacy/affiliate-tracking-domains
+++ b/privacy/affiliate-tracking-domains
@@ -5,6 +5,7 @@
 action.metaffiliation.com
 ad.atdmt.com
 ad.doubleclick.net
+adclick.g.doubleclick.net
 adfoc.us
 adj.st
 adservice.google.ac


### PR DESCRIPTION
Found when clicking on ads in Google search results, Facebook and RTL+.