### PR TITLE
Please add youtubekids.com

### DIFF
--- a/parentalcontrol/services/youtube
+++ b/parentalcontrol/services/youtube
@@ -13,5 +13,6 @@ youtube.pl
 youtubeeducation.com
 youtubegaming.com
 youtubei.googleapis.com
+youtubekids.com
 yt3.ggpht.com
 ytimg.com


### PR DESCRIPTION
Please add youtubekids.com to the "YouTube" list under "Websites, Apps & Games" in Parental Control.