### PR TITLE
Delete brave search,ecosia,and startpage from safesearch-not-supported

### DIFF
--- a/parentalcontrol/safesearch-not-supported
+++ b/parentalcontrol/safesearch-not-supported
@@ -2,7 +2,6 @@
 
 boomle.com
 dogpile.com
-ecosia.org
 gibiru.com
 gigablast.com
 go.mail.ru
@@ -13,10 +12,8 @@ nova.rambler.ru
 oscobo.com
 peekier.com
 search.aol.com
-search.brave.com
 search.yahoo.com
 searchencrypt.com
-startpage.com
 yippy.com
 you.com
 


### PR DESCRIPTION
brave search and ecosia have a safesearch and startpage have a family filter