### PR TITLE
Add AhaDNS to parental control bypass methods

### DIFF
--- a/parentalcontrol/bypass-methods
+++ b/parentalcontrol/bypass-methods
@@ -10,6 +10,7 @@ mask-h2.icloud.com
 a.ns.dnslify.com
 adblock.mydns.network
 adult-filter-dns.cleanbrowsing.org
+ahadns.net
 b.ns.dnslify.com
 canadianshield.cira.ca
 chrome.cloudflare-dns.com

--- a/parentalcontrol/bypass-methods
+++ b/parentalcontrol/bypass-methods
@@ -12,6 +12,7 @@ adblock.mydns.network
 adult-filter-dns.cleanbrowsing.org
 ahadns.net
 b.ns.dnslify.com
+blitz.ahadns.com
 canadianshield.cira.ca
 chrome.cloudflare-dns.com
 cloudflare-dns.com


### PR DESCRIPTION
Added ahadns.net.  Their DoH endpoints use the format https://doh.[LOCATION].ahadns.net/dns-query so I felt like blocking ahadns.net would be best. The full list is at https://ahadns.com/dns-over-https/