### PR TITLE
Add No Amazon blocklist

### DIFF
--- a/privacy/blocklists/no-amazon.json
+++ b/privacy/blocklists/no-amazon.json
@@ -1,0 +1,9 @@
+{
+  "name": "No Amazon",
+  "website": "https://github.com/nickspaargaren/no-amazon",
+  "description": "Completely block Amazon and its services.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/nickspaargaren/no-amazon/master/amazon.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
This pull request adds our [No Amazon blocklist](https://github.com/nickspaargaren/no-amazon) to NextDNS. This is a copy of the existing [no-google blocklist](https://github.com/nextdns/metadata/blob/master/privacy/blocklists/no-g.json).

Requested by @opq1: https://github.com/nickspaargaren/no-amazon/issues/38