### PR TITLE
Add tc.tradetracker.net

### DIFF
--- a/privacy/affiliate-tracking-domains
+++ b/privacy/affiliate-tracking-domains
@@ -433,3 +433,4 @@ www.emjcd.com
 www.googleadservices.com
 www.kdukvh.com
 www.partner-ads.com
+tc.tradetracker.net


### PR DESCRIPTION
If I search for Aerobiotic on Google, it shows me an adv from an eshop that I can't reach because tc.tradetracker.net is blocked.

Link:
```
https://www.googleadservices.com/pagead/aclk?sa=L&ai=DChcSEwjTjKnzxcP6AhWJ7-0KHZ9hB2sYABAOGgJkZw&ohost=www.google.com&cid=CAASJORow9j_m577rvTTMQ6SbnGyq_QN_QdV-gqIQw9Dc92t4Jqaqg&sig=AOD64_3U4ve8rU8IMYQsFlniGsyX4En3rw&ctype=5&q=&ved=2ahUKEwiDsqHzxcP6AhVtgP0HHdQLDLgQ9aACKAB6BAgCEC8&adurl=
```

Screenshot: https://ibb.co/gT9T03N