### PR TITLE
#1125 whitelist hashcat.net in pr0n list

### DIFF
--- a/parentalcontrol/categories/porn.json
+++ b/parentalcontrol/categories/porn.json
@@ -35,6 +35,7 @@
     "*.dickssportinggoods.com",
     "*.fastpic.ru",
     "*.findicons.com",
+    "*.hashcat.net",
     "*.jwpcdn.com",
     "*.meltwater.com",
     "*.menshealth.com",


### PR DESCRIPTION
whitelist hashcat.net from parental controls/porn - this is a misclassification. Fixes #1125 