### PR TITLE
Add Blocklist: HaGeZi - Multi PRO plus

### DIFF
--- a/privacy/blocklists/hagezi-multi-proplus.json
+++ b/privacy/blocklists/hagezi-multi-proplus.json
@@ -1,0 +1,9 @@
+{
+  "name": "HaGeZi - Multi PRO plus",
+  "website": "https://github.com/hagezi/dns-blocklists",
+  "description": "Sweeper - Aggressive cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.plus.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
Please add my Blocklist Multi PRO plus - Maximum protection: https://github.com/hagezi/dns-blocklists#proplus

My blocklists are based on [various sources](https://github.com/hagezi/dns-blocklists/blob/main/usedsources.md) and my own blacklists. They were designed to avoid [false positive domains](https://github.com/hagezi/dns-blocklists/blob/main/whitelist.txt) as much as possible and not to block any needed features. [Dead hosts](https://github.com/hagezi/dns-blocklists/blob/main/deadlist.txt) are regularly removed from the lists to keep them as small as possible. They are updated and maintained daily.

For more information see the [README](https://github.com/hagezi/dns-blocklists/blob/main/README.md).

Thanks,
Gerd