### PR TITLE
Add Blocklist: HaGeZi - Multi PRO

### DIFF
--- a/privacy/blocklists/hagezi-multi-pro.json
+++ b/privacy/blocklists/hagezi-multi-pro.json
@@ -1,0 +1,9 @@
+{
+  "name": "HaGeZi - Multi PRO",
+  "website": "https://github.com/hagezi/dns-blocklists",
+  "description": "Big broom - Cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
Please add my Blocklist Multi PRO - Extended protection: https://github.com/hagezi/dns-blocklists#pro

My blocklists are based on [various sources](https://github.com/hagezi/dns-blocklists/blob/main/usedsources.md) and my own blacklists. They were designed to avoid [false positive domains](https://github.com/hagezi/dns-blocklists/blob/main/whitelist.txt) as much as possible and not to block any needed features. [Dead hosts](https://github.com/hagezi/dns-blocklists/blob/main/deadlist.txt) are regularly removed from the lists to keep them as small as possible. They are updated and maintained daily.

For more information see the [README](https://github.com/hagezi/dns-blocklists/blob/main/README.md).

Thanks,
Gerd