### PR TITLE
Add Blocklist: HaGeZi - Multi NORMAL

### DIFF
--- a/privacy/blocklists/hagezi-multi-normal.json
+++ b/privacy/blocklists/hagezi-multi-normal.json
@@ -1,0 +1,9 @@
+{
+  "name": "HaGeZi - Multi NORMAL",
+  "website": "https://github.com/hagezi/dns-blocklists",
+  "description": "Broom - Cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/multi.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
Please add @hagezi's blocklist: HaGeZi - Multi NORMAL
https://github.com/hagezi/dns-blocklists

His blocklists are based on [various sources](https://github.com/hagezi/dns-blocklists/blob/main/usedsources.md) and his own blacklists. They were designed to avoid [false positive domains](https://github.com/hagezi/dns-blocklists/blob/main/whitelist.txt) as much as possible and not to block any needed features. [Dead hosts](https://github.com/hagezi/dns-blocklists/blob/main/deadlist.txt) are regularly removed from the lists to keep them as small as possible. They are updated and maintained daily.

For more information see the [README](https://github.com/hagezi/dns-blocklists/blob/main/README.md).