### PR TITLE
Add Blocklist: HaGeZi - Multi LIGHT

### DIFF
--- a/privacy/blocklists/hagezi-multi-light.json
+++ b/privacy/blocklists/hagezi-multi-light.json
@@ -1,0 +1,9 @@
+{
+  "name": "HaGeZi - Multi LIGHT",
+  "website": "https://github.com/hagezi/dns-blocklists",
+  "description": "Hand brush - Cleans the Internet and protects your privacy! Blocks Ads, Tracking, Metrics, some Malware and Fake.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/light.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
Please add @hagezi's blocklist: HaGeZi - Multi LIGHT
https://github.com/hagezi/dns-blocklists

His blocklists are based on [various sources](https://github.com/hagezi/dns-blocklists/blob/main/usedsources.md) and his own blacklists. They were designed to avoid [false positive domains](https://github.com/hagezi/dns-blocklists/blob/main/whitelist.txt) as much as possible and not to block any needed features. [Dead hosts](https://github.com/hagezi/dns-blocklists/blob/main/deadlist.txt) are regularly removed from the lists to keep them as small as possible. They are updated and maintained daily.

For more information see the [README](https://github.com/hagezi/dns-blocklists/blob/main/README.md).