### PR TITLE
[Add Blocklist] "Adblock Iran"

### DIFF
--- a/privacy/blocklists/adblock-iran.json
+++ b/privacy/blocklists/adblock-iran.json
@@ -1,0 +1,9 @@
+{
+  "name": "Adblock Iran",
+  "website": "https://github.com/farrokhi/adblock-iran",
+  "description": "A filter that enables to block most of Persian web ads",
+  "source": {
+    "url": "https://raw.githubusercontent.com/farrokhi/adblock-iran/master/pihole.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
Currently there isn't any blocklist for Persian ads in NextDNS list. This covers most of them, but some sites get advertisements directly from customer and host it on their own CDN. 
Additional note: This was originally supposed to be used with PiHole, but as it uses domains format it is compatible with NextDNS.
