### PR TITLE
Fix OISD list.

### DIFF
--- a/privacy/blocklists/oisd.json
+++ b/privacy/blocklists/oisd.json
@@ -3,7 +3,7 @@
   "website": "https://oisd.nl",
   "description": "Internet's #1 domain blocklist. Blocks Ads, Mobile Ads, Phishing, Malvertising, Malware, Tracking, Telemetry, CryptoJacking, Analytics, Spyware, Ransomware, Exploit, Fraud, Abuse, Scam, Spam, Hijack, Misleading Marketing.",
   "source": {
-    "url": "https://dblw.oisd.nl",
+    "url": "https://raw.githubusercontent.com/sjhgvr/oisd/main/dblw_full.txt",
     "format": "domains"
   }
 }


### PR DESCRIPTION
The oisd.nl domain seems to be non-functional at the moment, breaking the oisd list on NextDNS. Using the original GitHub source of the oisd.nl mirror will fix it.