### PR TITLE
Add additional aol search domains

### DIFF
--- a/parentalcontrol/safesearch-not-supported
+++ b/parentalcontrol/safesearch-not-supported
@@ -12,11 +12,15 @@ nigma.eu
 nova.rambler.ru
 oscobo.com
 peekier.com
+recherche.aol.fr
+search.aol.ca
 search.aol.com
+search.aol.co.uk
 search.brave.com
-search.yahoo.com
 searchencrypt.com
+search.yahoo.com
 startpage.com
+suche.aol.de
 yippy.com
 you.com
 


### PR DESCRIPTION
Hello people,

the SSL certificate of search.aol.com contains some more subject alternative names, that contain `aol`. I`ve tested and added them.

I think we should block AOL's search portals in other countries and languages as well. Other than that, I've sorted the first part of the list alphabetically.

Best regards,
Thomas
