### PR TITLE
Add fireball search engine

### DIFF
--- a/parentalcontrol/safesearch-not-supported
+++ b/parentalcontrol/safesearch-not-supported
@@ -3,6 +3,8 @@
 boomle.com
 dogpile.com
 ecosia.org
+fireball.com
+fireball.de
 gibiru.com
 gigablast.com
 go.mail.ru


### PR DESCRIPTION
Hello people,

the _fireball_ search engine failed my _safe search_ test although the corresponding option in my NextDNS settings was activated.

Refer to https://en.wikipedia.org/wiki/Fireball_(search_engine)

Best regards,
Thomas